### PR TITLE
Support videos in DepictionScreenshotsView

### DIFF
--- a/viewHandler.js
+++ b/viewHandler.js
@@ -146,7 +146,15 @@ function handleView(currentView,isStacked) {
             }
             if (currentView.hasOwnProperty('screenshots')) {
                 for (screenshotNum = 0; screenshotNum < currentView.screenshots.length; screenshotNum++) {
-                    var screenshot = document.createElement("img")
+                    var screenshot
+                    if (currentView.screenshots[screenshotNum].video) {
+                        screenshot = document.createElement("video");
+                        screenshot.setAttribute("controls", "");
+                    }
+                    else {
+                        screenshot = document.createElement("img");
+                    }
+
                     // Handle Screenshots differently on Cydia (BUT NOT Zebra)
                     if (navigator.userAgent.toLowerCase().includes("cydia") && !(navigator.userAgent.toLowerCase().includes("zebra"))) {
                         screenshot.setAttribute("onclick","screenshotViewCydia(this)")


### PR DESCRIPTION
Currently if you try to include a video in a DepictionScreenshotsView, it doesn't get shown properly. This change uses a video element instead when `video=True` is set in a screenshot object 